### PR TITLE
Version 1.5.3

### DIFF
--- a/assets/js/widgets/conductor-widget.js
+++ b/assets/js/widgets/conductor-widget.js
@@ -91,7 +91,8 @@ var conductor = conductor || {};
 				 * Default AJAX data
 				 */
 				default: {
-					conductor_widget: true
+					conductor_widget: true,
+					_wpnonce: conductor_widget.rest.nonce
 				},
 				/**
 				 * This function gets the AJAX data

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,9 +2,17 @@
 Plugin: Conductor
 Author: Slocum Themes/Slocum Design Studio
 Author URI: https://conductorplugin.com/
-Current Version: 1.5.2
+Current Version: 1.5.3
 ==========================================
 
+
+1.5.3 // May 20 2019
+--------------------
+- Added the "wp_rest" nonce to all Conductor REST API requests (allows for basic authentication checks
+  to be performed)
+- Fixed a possible issue where featured image sizes in Conductor widgets could be overridden via the
+  "post_thumbnail_size" filter
+- Fixed a possible PHP notice in the Conductor_Admin_Options PHP class when Conductor was used in an environment with PHP 7
 
 1.5.2 // February 01 2019
 -------------------------

--- a/conductor.php
+++ b/conductor.php
@@ -3,11 +3,11 @@
  * Plugin Name: Conductor
  * Plugin URI: https://www.conductorplugin.com/
  * Description: Build content-rich layouts in minutes without code.
- * Version: 1.5.2
+ * Version: 1.5.3
  * Author: Slocum Studio
  * Author URI: http://www.slocumstudio.com/
  * Requires at least: 4.4
- * Tested up to: 5.0.3
+ * Tested up to: 5.1.1
  * License: GPL2+
  *
  * Text Domain: conductor
@@ -23,7 +23,7 @@ if ( ! class_exists( 'Conductor' ) ) {
 		/**
 		 * @var string
 		 */
-		public static $version = '1.5.2';
+		public static $version = '1.5.3';
 
 		/**
 		 * @var Boolean, null by default so that we can cache the Boolean value

--- a/includes/admin/class-conductor-admin-options.php
+++ b/includes/admin/class-conductor-admin-options.php
@@ -4,7 +4,7 @@
  *
  * @class Conductor_Admin_Options
  * @author Slocum Studio
- * @version 1.5.0
+ * @version 1.5.3
  * @since 1.0.0
  */
 
@@ -17,7 +17,7 @@ if ( ! class_exists( 'Conductor_Admin_Options' ) ) {
 		/**
 		 * @var string
 		 */
-		public $version = '1.5.0';
+		public $version = '1.5.3';
 
 		/**
 		 * @var string
@@ -328,7 +328,7 @@ if ( ! class_exists( 'Conductor_Admin_Options' ) ) {
 										unset( $input['content_layouts'][$id] );
 
 									// Break out of the loop so the filter below doesn't run
-									continue;
+									break 2;
 								}
 
 								/*

--- a/includes/class-conductor-widget-default-query.php
+++ b/includes/class-conductor-widget-default-query.php
@@ -420,6 +420,7 @@ if ( ! class_exists( 'Conductor_Widget_Default_Query' ) ) {
 
 			// If we don't have a permalink structure and this widget has AJAX enabled
 			if ( ! $has_permalink_structure && $this->widget->has_ajax( $this->widget_instance, array() ) ) {
+				// TODO: Future: On archive pages, this likely doesn't work correctly (need to use get_pagenum_link() here?)
 				// Add the base argument to the paginate links arguments (remove the "page" and "paged" query arguments)
 				$paginate_links_args['base'] = html_entity_decode( remove_query_arg( array( 'page', 'paged' ), html_entity_decode( ( is_preview() ) ? esc_url( get_permalink() ) : get_pagenum_link() ) ) ) . '%_%';
 
@@ -427,6 +428,7 @@ if ( ! class_exists( 'Conductor_Widget_Default_Query' ) ) {
 				$paginate_links_args['format'] = ( ! $permalink_structure ) ? str_replace( '?', '&', $paginate_links_args['format'] ) : $paginate_links_args['format'];
 			}
 
+			// TODO: Future: On archive pages, this likely doesn't work correctly (need to use get_pagenum_link() here?)
 			// If we have a permalink structure and we're paged
 			if ( $has_permalink_structure && ( is_paged() || $page > 1 ) )
 				// Add the base argument to the paginate links arguments


### PR DESCRIPTION
- Added the "wp_rest" nonce to all Conductor REST API requests (allows for basic authentication checks to be performed)
- Fixed a possible issue where featured image sizes in Conductor widgets could be overridden via the "post_thumbnail_size" filter
- Fixed a possible PHP notice in the Conductor_Admin_Options PHP class when Conductor was used in an environment with PHP 7