### PR TITLE
Version 1.5.4

### DIFF
--- a/assets/js/widgets/conductor-widget.js
+++ b/assets/js/widgets/conductor-widget.js
@@ -512,7 +512,7 @@ var conductor = conductor || {};
 			}
 
 			var $this = $( event.currentTarget ),
-				paged_regex = new RegExp( '^' + conductor_widget.urls.current.permalink + '(?:.+)?([\\/?&](page[d]?)[\\/=])(\\d+)[\\/]?|^' + conductor_widget.urls.current.permalink + '[\\/](\\d+)[\\/]?$' ),
+				paged_regex = new RegExp( '^' + conductor_widget.urls.current.permalink + '(?:.+)?((?:[\\/?&]|%3[Ff])(page[d]?)(?:[\\/=]|%3[Dd]))(\\d+)[\\/]?|^' + conductor_widget.urls.current.permalink + '[\\/](\\d+)[\\/]?$' ),
 				$page_number,
 				$page_numbers = $this.parents( conductor_widget.css_selectors.pagination.page_numbers ),
 				$previous_page_number = $page_numbers.find( conductor_widget.css_selectors.pagination.previous ),

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,8 +2,18 @@
 Plugin: Conductor
 Author: Slocum Themes/Slocum Design Studio
 Author URI: https://conductorplugin.com/
-Current Version: 1.5.3
+Current Version: 1.5.4
 ==========================================
+
+
+1.5.4 // July 19 2019
+---------------------
+- Fixed an issue where pagination in AJAX was using an incorrect base permalink on archive pages; Thanks Lê Hoàng Giang
+- Added logic to detect the paged URL query argument surrounded by encoded characters (e.g. urlencode()) in preview
+  pagination links
+- Fixed a possible PHP warning when Conductor add-ons data could not be fetched; Thanks Henry Porter
+- Fixed an issue where free add-ons could not be installed via the Conductor Add-Ons page
+- Fixed a typo where "WordPress" was spelled incorrectly
 
 
 1.5.3 // May 20 2019

--- a/conductor.php
+++ b/conductor.php
@@ -3,11 +3,11 @@
  * Plugin Name: Conductor
  * Plugin URI: https://www.conductorplugin.com/
  * Description: Build content-rich layouts in minutes without code.
- * Version: 1.5.3
+ * Version: 1.5.4
  * Author: Slocum Studio
  * Author URI: http://www.slocumstudio.com/
  * Requires at least: 4.4
- * Tested up to: 5.1.1
+ * Tested up to: 5.2.2
  * License: GPL2+
  *
  * Text Domain: conductor
@@ -23,7 +23,7 @@ if ( ! class_exists( 'Conductor' ) ) {
 		/**
 		 * @var string
 		 */
-		public static $version = '1.5.3';
+		public static $version = '1.5.4';
 
 		/**
 		 * @var Boolean, null by default so that we can cache the Boolean value

--- a/includes/class-conductor-updates.php
+++ b/includes/class-conductor-updates.php
@@ -4,7 +4,7 @@
  *
  * @class Conductor_Updates
  * @author Slocum Studio
- * @version 1.5.2
+ * @version 1.5.4
  * @since 1.0.0
  */
 
@@ -17,7 +17,7 @@ if ( ! class_exists( 'Conductor_Updates' ) ) {
 		/**
 		 * @var string
 		 */
-		public $version = '1.5.2';
+		public $version = '1.5.4';
 
 		/**
 		 * @var string, URL

--- a/includes/class-conductor-widget-default-query.php
+++ b/includes/class-conductor-widget-default-query.php
@@ -5,7 +5,7 @@
  *
  * @class Conductor_Widget_Default_Query
  * @author Slocum Studio
- * @version 1.5.2
+ * @version 1.5.4
  * @since 1.0.0
  */
 
@@ -18,7 +18,7 @@ if ( ! class_exists( 'Conductor_Widget_Default_Query' ) ) {
 		/**
 		 * @var string
 		 */
-		public $version = '1.5.2';
+		public $version = '1.5.4';
 
 		/**
 		 * @var WP_Widget, Conductor Widget
@@ -418,9 +418,8 @@ if ( ! class_exists( 'Conductor_Widget_Default_Query' ) ) {
 			if ( apply_filters( 'conductor_query_paginate_links_is_single', is_single(), $has_permalink_structure, $paginate_links_args, $query, $echo, $this ) )
 				$paginate_links_args['format'] = ( $has_permalink_structure ) ? '%#%/' : '?page=%#%'; // %#% will be replaced with page number
 
-			// If we don't have a permalink structure and this widget has AJAX enabled
-			if ( ! $has_permalink_structure && $this->widget->has_ajax( $this->widget_instance, array() ) ) {
-				// TODO: Future: On archive pages, this likely doesn't work correctly (need to use get_pagenum_link() here?)
+			// If we don't have a permalink structure or this is a preview and this widget has AJAX enabled
+			if ( ( ! $has_permalink_structure || is_preview() ) && $this->widget->has_ajax( $this->widget_instance, array() ) ) {
 				// Add the base argument to the paginate links arguments (remove the "page" and "paged" query arguments)
 				$paginate_links_args['base'] = html_entity_decode( remove_query_arg( array( 'page', 'paged' ), html_entity_decode( ( is_preview() ) ? esc_url( get_permalink() ) : get_pagenum_link() ) ) ) . '%_%';
 
@@ -428,11 +427,10 @@ if ( ! class_exists( 'Conductor_Widget_Default_Query' ) ) {
 				$paginate_links_args['format'] = ( ! $permalink_structure ) ? str_replace( '?', '&', $paginate_links_args['format'] ) : $paginate_links_args['format'];
 			}
 
-			// TODO: Future: On archive pages, this likely doesn't work correctly (need to use get_pagenum_link() here?)
 			// If we have a permalink structure and we're paged
 			if ( $has_permalink_structure && ( is_paged() || $page > 1 ) )
-				// Add the base argument to the paginate links arguments
-				$paginate_links_args['base'] = get_permalink() . '%_%';
+				// Add the base argument to the paginate links arguments (remove the "page" and "paged" query arguments)
+				$paginate_links_args['base'] = html_entity_decode( remove_query_arg( array( 'page', 'paged' ), html_entity_decode( ( is_preview() ) ? esc_url( get_permalink() ) : get_pagenum_link() ) ) ) . '%_%';
 
 			$paginate_links_args = apply_filters( 'conductor_query_paginate_links_args', $paginate_links_args, $query, $echo, $this, $has_permalink_structure );
 

--- a/includes/widgets/class-conductor-widget.php
+++ b/includes/widgets/class-conductor-widget.php
@@ -4,7 +4,7 @@
  *
  * @class Conductor_Widget
  * @author Slocum Studio
- * @version 1.5.3
+ * @version 1.5.4
  * @since 1.0.0
  */
 
@@ -17,7 +17,7 @@ if ( ! class_exists( 'Conductor_Widget' ) ) {
 		/**
 		 * @var string
 		 */
-		public $version = '1.5.3';
+		public $version = '1.5.4';
 
 		/**
 		 * @var array, Conductor Widget defaults
@@ -1758,7 +1758,7 @@ if ( ! class_exists( 'Conductor_Widget' ) ) {
 					'urls' => array(
 						// Current
 						'current' => array(
-							'permalink' => str_replace( '?', '\\?', untrailingslashit( get_permalink() ) ),
+							'permalink' => str_replace( '?', '\\?', untrailingslashit( html_entity_decode( remove_query_arg( array( 'page', 'paged' ), html_entity_decode( ( is_preview() ) ? esc_url( get_permalink() ) : get_pagenum_link() ) ) ) ) ),
 						),
 						// REST API
 						'rest' => array(
@@ -3211,7 +3211,7 @@ if ( ! class_exists( 'Conductor_Widget' ) ) {
 							<input type="checkbox" class="conductor-input conductor-rest-enabled-value" id="<?php echo $this->get_field_id( 'rest_enabled' ); ?>" name="<?php echo $this->get_field_name( 'rest_enabled' ); ?>" <?php checked( $instance['rest']['enabled'] ); ?> <?php disabled( ! $conductor_options['rest']['enabled'] ); ?> data-default="<?php echo esc_attr( ( $this->defaults['rest']['enabled'] ) ? 'true' : false ); ?>" />
 							<label for="<?php echo $this->get_field_id( 'rest_enabled' ); ?>"><strong><?php _e( 'Enable in REST API', 'conductor' ); ?></strong></label>
 							<br />
-							<small class="description conductor-description"><?php _e( 'Enable this Conductor Widget in the Conductor REST API. If unchecked, this Conductor Widget will not be accessible via the Conductor WordPres REST API.', 'conductor' ); ?></small>
+							<small class="description conductor-description"><?php _e( 'Enable this Conductor Widget in the Conductor REST API. If unchecked, this Conductor Widget will not be accessible via the Conductor WordPress REST API.', 'conductor' ); ?></small>
 							<?php
 								// If the Conductor REST API is not enabled
 								if ( ! $conductor_options['rest']['enabled'] ) :


### PR DESCRIPTION
- Fixed an issue where pagination in AJAX was using an incorrect base permalink on archive pages; Thanks Lê Hoàng Giang
- Added logic to detect the paged URL query argument surrounded by encoded characters (e.g. urlencode()) in preview pagination links
- Fixed a possible PHP warning when Conductor add-ons data could not be fetched; Thanks Henry Porter
- Fixed an issue where free add-ons could not be installed via the Conductor Add-Ons page
- Fixed a typo where "WordPress" was spelled incorrectly